### PR TITLE
Remove LiveData calendar refresh

### DIFF
--- a/app/src/main/java/app/getfeeling/feeling/repository/FeelingRepository.kt
+++ b/app/src/main/java/app/getfeeling/feeling/repository/FeelingRepository.kt
@@ -24,8 +24,6 @@ class FeelingRepository @Inject constructor(private val feelingDao: FeelingDao) 
             yearMonth.year.toString()
         )
 
-    override fun getAllFeelings(): LiveData<List<Feeling>> = feelingDao.getAll()
-
     override suspend fun addFeeling(feeling: Feeling) = withContext(Dispatchers.IO) {
         feelingDao.insert(feeling)
     }

--- a/app/src/main/java/app/getfeeling/feeling/repository/interfaces/IFeelingRepository.kt
+++ b/app/src/main/java/app/getfeeling/feeling/repository/interfaces/IFeelingRepository.kt
@@ -10,7 +10,5 @@ interface IFeelingRepository {
 
     fun getFeelings(yearMonth: YearMonth): List<Feeling>
 
-    fun getAllFeelings(): LiveData<List<Feeling>>
-
     suspend fun addFeeling(feeling: Feeling)
 }

--- a/app/src/main/java/app/getfeeling/feeling/room/dao/FeelingDao.kt
+++ b/app/src/main/java/app/getfeeling/feeling/room/dao/FeelingDao.kt
@@ -16,9 +16,6 @@ interface FeelingDao {
     @Query("SELECT * FROM feelings WHERE strftime('%m', createdAt) = :month AND strftime('%Y', createdAt) = :year")
     fun get(month: String, year: String): List<Feeling>
 
-    @Query("SELECT * FROM feelings")
-    fun getAll(): LiveData<List<Feeling>>
-
     @Insert
     suspend fun insert(feeling: Feeling)
 

--- a/app/src/main/java/app/getfeeling/feeling/ui/me/FeelingMonthDataSourceFactory.kt
+++ b/app/src/main/java/app/getfeeling/feeling/ui/me/FeelingMonthDataSourceFactory.kt
@@ -1,6 +1,5 @@
 package app.getfeeling.feeling.ui.me
 
-import androidx.lifecycle.MutableLiveData
 import androidx.paging.DataSource
 import app.getfeeling.feeling.repository.FeelingRepository
 import org.threeten.bp.YearMonth
@@ -9,11 +8,6 @@ import org.threeten.bp.YearMonth
 class FeelingMonthDataSourceFactory(private val feelingRepository: FeelingRepository) :
     DataSource.Factory<YearMonth, FeelingMonth>() {
 
-    val sourceLiveData = MutableLiveData<FeelingMonthDataSource>()
-
-    override fun create(): DataSource<YearMonth, FeelingMonth> {
-        val latestSource = FeelingMonthDataSource(feelingRepository)
-        sourceLiveData.postValue(latestSource)
-        return latestSource
-    }
+    override fun create(): DataSource<YearMonth, FeelingMonth> =
+        FeelingMonthDataSource(feelingRepository)
 }

--- a/app/src/main/java/app/getfeeling/feeling/ui/me/MeFragment.kt
+++ b/app/src/main/java/app/getfeeling/feeling/ui/me/MeFragment.kt
@@ -50,9 +50,6 @@ class MeFragment : DaggerFragment() {
 
         meViewModel.getUser()
         meViewModel.feelingMonths.observe(this, calendarMonthAdapter::submitList)
-        meViewModel.allFeelings.observe(this) {
-            meViewModel.invalidateDataSource()
-        }
 
         with(binding) {
             viewModel = meViewModel

--- a/app/src/main/java/app/getfeeling/feeling/ui/me/MeViewModel.kt
+++ b/app/src/main/java/app/getfeeling/feeling/ui/me/MeViewModel.kt
@@ -6,10 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.LivePagedListBuilder
 import androidx.paging.PagedList
-import app.getfeeling.feeling.repository.interfaces.IFeelingRepository
 import app.getfeeling.feeling.repository.interfaces.ITokenRepository
 import app.getfeeling.feeling.repository.interfaces.IUserRepository
-import app.getfeeling.feeling.valueobjects.Feeling
 import app.getfeeling.feeling.valueobjects.User
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -18,8 +16,7 @@ import javax.inject.Inject
 class MeViewModel @Inject constructor(
     private val userRepository: IUserRepository,
     tokenRepository: ITokenRepository,
-    feelingRepository: IFeelingRepository,
-    private val feelingMonthDataSourceFactory: FeelingMonthDataSourceFactory,
+    feelingMonthDataSourceFactory: FeelingMonthDataSourceFactory,
     pagedListConfig: PagedList.Config
 ) : ViewModel() {
 
@@ -27,8 +24,6 @@ class MeViewModel @Inject constructor(
 
     private val _user: MediatorLiveData<User?> = MediatorLiveData()
     val user: LiveData<User?> = _user
-
-    val allFeelings: LiveData<List<Feeling>> = feelingRepository.getAllFeelings()
 
     val feelingMonths: LiveData<PagedList<FeelingMonth>> =
         LivePagedListBuilder(feelingMonthDataSourceFactory, pagedListConfig).build()
@@ -40,6 +35,4 @@ class MeViewModel @Inject constructor(
             }
         }
     }
-
-    fun invalidateDataSource() = feelingMonthDataSourceFactory.sourceLiveData.value?.invalidate()
 }

--- a/app/src/main/res/layout/calendar_day.xml
+++ b/app/src/main/res/layout/calendar_day.xml
@@ -4,7 +4,7 @@
         xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout"
+            android:id="@+id/layout_calenday_day"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:paddingStart="3dp"

--- a/app/src/main/res/layout/calendar_month.xml
+++ b/app/src/main/res/layout/calendar_month.xml
@@ -3,6 +3,7 @@
         xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
+            android:id="@+id/layout_calendar_month"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"

--- a/app/src/main/res/layout/me_fragment.xml
+++ b/app/src/main/res/layout/me_fragment.xml
@@ -11,7 +11,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/main"
+            android:id="@+id/layout_me"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             tools:background="@color/colorLight"


### PR DESCRIPTION
We don't need the annoying flashing everytime it opens for now. Was reworking the livedata to move the feeling repo call into the calendar day adapter but that resulted in even worse "flashing" of the feelings. Going to wait until the paging library gets updated before revisiting this anymore